### PR TITLE
Handle several config files through patterns

### DIFF
--- a/tasks/gruntacular.js
+++ b/tasks/gruntacular.js
@@ -5,15 +5,35 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('testacular', 'run testacular.', function() {
     var done = this.async();
     if (this.data.configFile) {
-      this.data.configFile = grunt.template.process(this.data.configFile);
+      var self = this;
+      var files = grunt.file.expand(this.data.configFile);
+      grunt.util.async.reduce(
+	files,
+	true,
+	function(memo, file, cb) {
+	  self.data.configFile = grunt.template.process(file);
+	  execute(self.data, self.flags, function(ret) {
+	      cb(undefined, memo && ret);
+	  });
+	},
+	function(err, result) {
+	  done(result);
+	}
+      );
+    } else {
+      execute(this.data, this.flags, done);
     }
-    //support `testacular run`, useful for grunt watch
-    if (this.flags.run){
-      runner.run(this.data, finished.bind(done));
-      return;
-    }
-    server.start(this.data, finished.bind(done));
   });
+};
+
+var execute = function(data, flags, cb) {
+  //support `testacular run`, useful for grunt watch
+  if (flags.run) {
+    runner.run(data, finished.bind(cb));
+    return;
+  }
+
+  server.start(data, finished.bind(cb));
 };
 
 function finished(code){ return this(code === 0); }


### PR DESCRIPTION
- With this change, several config files defined in the configFile option with
  patterns are executed serially. If any of the tests fails, the task fails.
- For example you can use: configFile: 'test/**/testacular.conf.js'
